### PR TITLE
V22F-926 Fix Failing Debug Assertion

### DIFF
--- a/speed-dreams/source-2.2.3/data/data/menu/DatabaseSettingsMenu.xml
+++ b/speed-dreams/source-2.2.3/data/data/menu/DatabaseSettingsMenu.xml
@@ -156,8 +156,8 @@
             <attstr name="text" val="Client Authority Certificate:"/>
             <attstr name="h align" val="left"/>
             <attstr name="font" val="medium_t"/>
-
-		
+        </section>
+        
         <!-- Delete password button -->
         <section name="DeletePasswordButton">
             <attstr name="type" val="text button"/>


### PR DESCRIPTION
Adds a closing section tag to section CaCertLabel in DatabaseSettingsMenu.xml. (also converts the tabs in this section to spaces)
This fixes a debug assertion where this file is not read properly, passing nullptr to strcpy_s as a result.