### PR TITLE
V22F-920 Use save data settings

### DIFF
--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DatabaseSettingsMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DatabaseSettingsMenu.cpp
@@ -199,6 +199,7 @@ void* DatabaseSettingsMenuInit(void* p_nextMenu)
     control.PrivateCertificateButton = m_privateCertFileDialogControl;
     control.PrivateCertificateLabel = m_publicCertDialogLabel;
     LoadDBSettings(s_scrHandle, control);
+    SetDBSettings();
     SynchronizeControls(s_scrHandle, control, m_caCertLabel, m_publicCertLabel, m_privateCertLabel);
 
     return s_scrHandle;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/DecisionMaker.inl
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/DecisionMaker.inl
@@ -152,7 +152,7 @@ void TEMP_DECISIONMAKER::CloseRecorder()
 template <typename SocketBlackBox, typename SDAConfig, typename FileDataStorage, typename SQLDatabaseStorage, typename Recorder>
 void TEMP_DECISIONMAKER::SaveData()
 {
-    SQLDatabaseStorage sqlDatabaseStorage;
+    SQLDatabaseStorage sqlDatabaseStorage(Config.GetDataCollectionSetting());
     sqlDatabaseStorage.Run(m_bufferPaths);
 }
 

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionMakerTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionMakerTests.cpp
@@ -194,7 +194,6 @@ TEST(DecisionMakerTests, RaceStopTest)
     ASSERT_TRUE(SetupSingletonsFolder());
     TDecisionMaker decisionMaker;
     InitializeTest(decisionMaker);
-    decisionMaker.SetDataCollectionSettings({true, true, true});
     chdir(SD_DATADIR_SRC);
 
     ASSERT_NO_THROW(decisionMaker.CloseRecorder());

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionMakerTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionMakerTests.cpp
@@ -194,13 +194,14 @@ TEST(DecisionMakerTests, RaceStopTest)
     ASSERT_TRUE(SetupSingletonsFolder());
     TDecisionMaker decisionMaker;
     InitializeTest(decisionMaker);
+    decisionMaker.SetDataCollectionSettings({true, true, true});
     chdir(SD_DATADIR_SRC);
 
     ASSERT_NO_THROW(decisionMaker.CloseRecorder());
     ASSERT_NO_THROW(decisionMaker.SaveData());
     ASSERT_NO_THROW(decisionMaker.ShutdownBlackBox());
 
-    tBufferPaths vsBufferPaths = *static_cast<tBufferPaths*>(VariableStore::GetInstance().Variables[0]);
+    tBufferPaths vsBufferPaths = *static_cast<tBufferPaths*>(VariableStore::GetInstance().Variables[1]);
     tBufferPaths dmBufferPaths = decisionMaker.GetBufferPaths();
     ASSERT_EQ(vsBufferPaths.MetaData, dmBufferPaths.MetaData);
     ASSERT_EQ(vsBufferPaths.TimeSteps, dmBufferPaths.TimeSteps);
@@ -209,6 +210,31 @@ TEST(DecisionMakerTests, RaceStopTest)
     ASSERT_EQ(vsBufferPaths.Decisions, dmBufferPaths.Decisions);
     ASSERT_EQ(nullptr, decisionMaker.GetRecorder());
 }
+
+/// @brief Tests whether the DataToStore is correctly set in the SQLDataBaseStorage when calling SaveData.
+/// @param p_carData          Whether to store gamestate car data.
+/// @param p_humanData        Whether to store human user input data.
+/// @param p_interventionData Whether to store invervention decision data.
+void TestOnlySaveDataToStore(bool p_carData, bool p_humanData, bool p_interventionData)
+{
+    SDAConfigMediator::ClearInstance();
+    ASSERT_TRUE(SetupSingletonsFolder());
+    TDecisionMaker decisionMaker;
+    InitializeTest(decisionMaker);
+    decisionMaker.SetDataCollectionSettings({false, p_carData, p_humanData, p_interventionData});
+    decisionMaker.SaveData();
+
+    // Assert whether the dataToStore is correctly stored in the variable store (by the SQLDatabaseStorageMock)
+    tDataToStore storedDataToStore = *static_cast<tDataToStore*>(VariableStore::GetInstance().Variables[0]);
+    ASSERT_EQ(p_carData, storedDataToStore.CarData);
+    ASSERT_EQ(p_humanData, storedDataToStore.HumanData);
+    ASSERT_EQ(p_interventionData, storedDataToStore.InterventionData);
+}
+
+/// @brief Run the TestOnlySaveDataToStore(bool,bool,bool) test with all possible combinations.
+BEGIN_TEST_COMBINATORIAL(DecisionMakerTests, OnlySaveDataToStoreTest)
+bool booleans[2]{true, false};
+END_TEST_COMBINATORIAL3(TestOnlySaveDataToStore, booleans, 2, booleans, 2, booleans, 2)
 
 /// @brief Tests if the GetFileDataStorage correctly gets the variable
 TEST(DecisionMakerTests, GetFileDataStorageTest)

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/mocks/SQLDatabaseStorageMock.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/mocks/SQLDatabaseStorageMock.h
@@ -10,16 +10,21 @@
 class SQLDatabaseStorageMock : IDataStorage
 {
 public:
-    SQLDatabaseStorageMock() {}
+    SQLDatabaseStorageMock()
+        : SQLDatabaseStorageMock({true, true, true, true}) {}
 
     SQLDatabaseStorageMock(tDataToStore p_dataToStore)
-        : SQLDatabaseStorageMock() {}
+    {
+        const auto dataToStore = new tDataToStore(p_dataToStore);
+
+        VariableStore::GetInstance().Variables[0] = static_cast<void*>(dataToStore);
+    }
 
     void Run(const tBufferPaths& p_bufferPaths)
     {
         const auto bufferPaths = new tBufferPaths(p_bufferPaths);
 
-        VariableStore::GetInstance().Variables[0] = static_cast<void*>(bufferPaths);
+        VariableStore::GetInstance().Variables[1] = static_cast<void*>(bufferPaths);
     }
 
     bool StoreData(const tBufferPaths& p_bufferPaths) override  // @NOCOVERAGE, This function definition is needed for building (IDataStorage is abstract), but will not be used and therefore not covered.

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/mocks/SQLDatabaseStorageMock.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/mocks/SQLDatabaseStorageMock.h
@@ -13,7 +13,7 @@ public:
     SQLDatabaseStorageMock()
         : SQLDatabaseStorageMock({true, true, true, true}) {}
 
-    SQLDatabaseStorageMock(tDataToStore p_dataToStore)
+    explicit SQLDatabaseStorageMock(tDataToStore p_dataToStore)
     {
         const auto dataToStore = new tDataToStore(p_dataToStore);
 


### PR DESCRIPTION
- This fixes a bug where the save data settings were not used
- Also created a test to prevent the same mistake in the future.
- Also fixed a bug where db credential settings were nog used if the menu was skipped.