### PR TITLE
V22F-962 Fix memory leaks

### DIFF
--- a/speed-dreams/source-2.2.3/data/data/menu/ResearcherMenu.xml
+++ b/speed-dreams/source-2.2.3/data/data/menu/ResearcherMenu.xml
@@ -80,7 +80,7 @@
             <attnum name="x" val="540"/>
             <attnum name="y" val="170"/>
             <attstr name="tip" val="The speed of the black box"/>
-            <attstr name="text" val="Unknown       "/>
+            <attstr name="text" val="Unknown         "/>
             <attstr name="h align" val="right"/>
             <attstr name="font" val="medium_t"/>
         </section>

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -462,7 +462,7 @@ void LoadIndicatorTextures()
 {
     std::vector<tIndicatorData> indicators = IndicatorConfig::GetInstance()->GetIndicatorData();
     m_texturesSize = indicators.size();
-    m_textures = new ssgSimpleState *[m_texturesSize];
+    m_textures = new ssgSimpleState*[m_texturesSize];
     for (const tIndicatorData& indicator : indicators)
     {
         ssgSimpleState* texture = nullptr;
@@ -475,6 +475,7 @@ void LoadIndicatorTextures()
     }
 }
 
+// DAISI
 /// @brief Releases all indicator data textures, textures loaded in from the same path are pointing to the same texture.
 ///        Therefore, we have to check whether the texture was already deleted.
 void ReleaseIndicatorTextures()

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -719,13 +719,13 @@ void cGrBoard::ReadDashColor(void *hdle, const string &color_name, float **color
   }
 }
 
-/// @brief Initializes the dashboard by creating a trackmap object.
+/// @brief Initializes the dashboard
 void cGrBoard::initBoard(void)
 {
 }
 
-/// @brief Shuts down the dashboard by releasing the trackmap object memory.
+/// @brief Shuts down the dashboard by releasing the indicator textures.
 void cGrBoard::shutdown(void)
 {
-    if(m_textures) ReleaseIndicatorTextures();
+    if (m_textures) ReleaseIndicatorTextures();
 }

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -485,6 +485,7 @@ void ReleaseIndicatorTextures()
     {
         if (std::find(deletedPointers.begin(), deletedPointers.end(), m_textures[i]) != deletedPointers.end()) continue;
         deletedPointers.emplace_back(m_textures[i]);
+        GfTexFreeTexture(m_textures[i]->getTextureHandle());
         delete m_textures[i];
     }
     delete[] m_textures;

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -480,11 +480,11 @@ void LoadIndicatorTextures()
 ///        Therefore, we have to check whether the texture was already deleted.
 void ReleaseIndicatorTextures()
 {
-    std::vector<int> deletedPointers;
+    std::vector<ssgSimpleState*> deletedPointers;
     for (int i = 0; i < m_texturesSize; i++)
     {
-        if (std::find(deletedPointers.begin(), deletedPointers.end(), (int)m_textures[i]) != deletedPointers.end()) continue;
-        deletedPointers.emplace_back((int)(m_textures[i]));
+        if (std::find(deletedPointers.begin(), deletedPointers.end(), m_textures[i]) != deletedPointers.end()) continue;
+        deletedPointers.emplace_back(m_textures[i]);
         delete m_textures[i];
     }
     delete[] m_textures;

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DataCompressionMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DataCompressionMenu.cpp
@@ -75,6 +75,7 @@ static void LoadSettings()
         // Initialize settings with the retrieved xml file
         LoadSettingsFromFile(param);
         SynchronizeControls();
+        GfParmReleaseHandle(param);
         return;
     }
     LoadDefaultSettings();
@@ -100,6 +101,7 @@ static void SaveSettingsToFile()
 
     // Write queued changes
     GfParmWriteFile(nullptr, readParam, COMPRESSION_SCREEN_NAME);
+    GfParmReleaseHandle(readParam);
 }
 
 /// @brief Saves the settings so the mediator (or future instances) can access them

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DatabaseConnectionManager.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DatabaseConnectionManager.cpp
@@ -81,6 +81,7 @@ void SaveDBSettingsToDisk()
 
     // Write all the above queued changed to xml file
     GfParmWriteFile(nullptr, readParam, "DatabaseSettingsMenu");
+    GfParmReleaseHandle(readParam);
 }
 
 /// @brief Synchronizes all the menu controls in the database settings menu to the internal variables
@@ -186,6 +187,7 @@ void LoadDBSettings(void* p_scrHandle, tDbControlSettings& p_control)
         void* param = GfParmReadFile(buf, GFPARM_RMODE_STD);
         // Initialize settings with the retrieved xml file
         LoadConfigSettings(param, p_control);
+        GfParmReleaseHandle(param);
         return;
     }
     LoadDefaultSettings(p_scrHandle, p_control);
@@ -282,6 +284,7 @@ void DeletePassword(void* p_scrHandle, int p_passwordControl)
     void* readParam = GfParmReadFile(dst, GFPARM_RMODE_REREAD | GFPARM_RMODE_CREAT);
     GfParmSetStr(readParam, PRM_PASSWORD, GFMNU_ATTR_TEXT, "");
     GfParmWriteFile(nullptr, readParam, "DatabaseSettingsMenu");
+    GfParmReleaseHandle(readParam);
 }
 
 /// @brief Fill in the saved password

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DeveloperMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DeveloperMenu.cpp
@@ -343,8 +343,8 @@ static void SetDefaultThresholdValues(void*)
     // load the xmlhandle
     char buf[512];
     sprintf(buf, "%s%s", GfDataDir(), DEV_XMLPATH);
-    void* m_xmlHandle = GfParmReadFile(buf, GFPARM_RMODE_STD);
-    if (m_xmlHandle == nullptr)
+    void* xmlHandle = GfParmReadFile(buf, GFPARM_RMODE_STD);
+    if (xmlHandle == nullptr)
         throw std::invalid_argument("DeveloperMenu.xml does not exists");
 
     // load the path in the xml based on the intervention type
@@ -356,14 +356,16 @@ static void SetDefaultThresholdValues(void*)
     m_path += s_interventionTypeString[m_tempInterventionType];
 
     // set the values to their default determined by the xml file.
-    m_decisionThresholds.Accel = GfParmGetNum(m_xmlHandle, m_path.c_str(), GFMNU_ATT_ACCEL, nullptr, 0.9f);
-    m_decisionThresholds.Brake = GfParmGetNum(m_xmlHandle, m_path.c_str(), GFMNU_ATT_BRAKE, nullptr, 0.9f);
-    m_decisionThresholds.Steer = GfParmGetNum(m_xmlHandle, m_path.c_str(), GFMNU_ATT_STEER, nullptr, 0.05f);
+    m_decisionThresholds.Accel = GfParmGetNum(xmlHandle, m_path.c_str(), GFMNU_ATT_ACCEL, nullptr, 0.9f);
+    m_decisionThresholds.Brake = GfParmGetNum(xmlHandle, m_path.c_str(), GFMNU_ATT_BRAKE, nullptr, 0.9f);
+    m_decisionThresholds.Steer = GfParmGetNum(xmlHandle, m_path.c_str(), GFMNU_ATT_STEER, nullptr, 0.05f);
 
     // set the edit boxes to the correct value
     WriteThresholdValue(m_decisionThresholds.Accel, m_accelThresholdControl);
     WriteThresholdValue(m_decisionThresholds.Brake, m_brakeThresholdControl);
     WriteThresholdValue(m_decisionThresholds.Steer, m_steerThresholdControl);
+
+    GfParmReleaseHandle(xmlHandle);
 }
 
 /// @brief Set the default values of threshold boxes based on the InterventionType.

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DeveloperMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/mainscreens/DeveloperMenu.cpp
@@ -104,8 +104,6 @@ static void LoadSettingsFromFile(void* p_param)
     Clamp(m_decisionThresholds.Accel, 0.0f, 1.0f);
     Clamp(m_decisionThresholds.Brake, 0.0f, 1.0f);
     Clamp(m_decisionThresholds.Steer, 0.0f, 1.0f);
-
-    GfParmReleaseHandle(p_param);
 }
 
 /// @brief Makes sure all visuals display the internal values
@@ -183,7 +181,6 @@ static void SaveSettingsToFile()
 
     // Write queued changes
     GfParmWriteFile(nullptr, readParam, DEV_SCREEN_NAME);
-
     GfParmReleaseHandle(readParam);
 }
 

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/racescreens/EndExperimentMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/racescreens/EndExperimentMenu.cpp
@@ -27,4 +27,5 @@ void RmShowEndExperiment(RaceEndType p_raceEndType)
     GfuiAddKey(s_menuHandle, GFUIK_RETURN, "Continue", prevHandle, GfuiScreenReplace, nullptr);
 
     GfuiScreenActivate(s_menuHandle);
+    GfParmReleaseHandle(param);
 }

--- a/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/racescreens/SaveMenu.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/userinterface/legacymenu/racescreens/SaveMenu.cpp
@@ -97,5 +97,7 @@ void* SaveMenuInit(RaceEndType p_raceEndType)
         GfuiScreenActivate(s_menuHandle);
     }
 
+    GfParmReleaseHandle(param);
+
     return s_menuHandle;
 }

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -298,7 +298,7 @@ Changed:
                         included <ConfigEnums.h>
                         removed the help menu and other unnecessary functionalities for experiments when FORCE_EXPERIMENT_SETUP is defined
                 CMakeList.txt
-                  added    ResearcherMenu.h and .cppy
+                  added    ResearcherMenu.h and .cpp
                   added    DataSelectionMenu.h and .cpp
                   added    SaveMenu.cpp
                   added    ConfirmationMenu.cpp

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -422,12 +422,14 @@ Changed:
                     included "Mediator.h"
                     included "IndicatorConfig.h"
 
-                    added   m_textures array
+                    added   m_textures     array
+                    added   m_texturesSize int
 
                     added   DispActiveIndicators()
                     added   DispIndicatorIcon();
                     added   DispIndicatorText();
                     added   LoadIndicatorTextures()
+                    added   ReleaseIndicatorTextures()
 
                     changed cGrBoard(): removed assignments of removed members
                     changed ~cGrBoard(): removed deletes of removed members

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -298,7 +298,7 @@ Changed:
                         included <ConfigEnums.h>
                         removed the help menu and other unnecessary functionalities for experiments when FORCE_EXPERIMENT_SETUP is defined
                 CMakeList.txt
-                  added    ResearcherMenu.h and .cpp
+                  added    ResearcherMenu.h and .cppy
                   added    DataSelectionMenu.h and .cpp
                   added    SaveMenu.cpp
                   added    ConfirmationMenu.cpp

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/Mediator.inl
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/Mediator.inl
@@ -324,8 +324,8 @@ void Mediator<DecisionMaker>::RaceStart(tTrack* p_track, void* p_carHandle, void
     std::cout << blackBoxFilePath << std::endl;
 
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, GetInterventionType());
 
     // Initialize the decision maker with the full path to the current black box executable

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backend/SQLDatabaseStorage.h
@@ -18,6 +18,7 @@ class SQLDatabaseStorage : IDataStorage
 public:
     SQLDatabaseStorage();
     explicit SQLDatabaseStorage(tDataToStore p_dataToStore);
+    ~SQLDatabaseStorage();
 
     bool TestConnection(DatabaseSettings p_dbSettings);
     bool Run(const tBufferPaths& p_bufferPaths);

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/CarControllerTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/CarControllerTests.cpp
@@ -130,8 +130,8 @@ void ShowInterventionTest(InterventionAction p_action)
     GfSetDataDir(SD_DATADIR_SRC);
 
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, SMediator::GetInstance()->GetInterventionType());
 
     CarController carController;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionsTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/DecisionsTests.cpp
@@ -154,8 +154,8 @@ INSTANTIATE_TEST_SUITE_P(RunInterveneDecisions, DecisionTestCombinatorial,
 TEST_P(DecisionTest, BrakeRunIndicateTest)
 {
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, SMediator::GetInstance()->GetInterventionType());
 
     tAllowedActions allowedActions;
@@ -187,8 +187,8 @@ TEST_P(DecisionTest, SteerRunIndicateTests)
     SMediator::GetInstance()->SetInterventionType(INTERVENTION_TYPE_AUTONOMOUS_AI);
 
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, SMediator::GetInstance()->GetInterventionType());
 
     tAllowedActions allowedActions;
@@ -224,8 +224,8 @@ INSTANTIATE_TEST_SUITE_P(SteerRunIndicateTests, DecisionTest,
 TEST_P(DecisionTest, AccelRunIndicateTests)
 {
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, SMediator::GetInstance()->GetInterventionType());
 
     tAllowedActions allowedActions;
@@ -256,8 +256,8 @@ TEST_P(DecisionTestCombinatorialFloat, MultipleIndicatorTest)
     SMediator::GetInstance()->SetInterventionType(INTERVENTION_TYPE_SHARED_CONTROL);
 
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, SMediator::GetInstance()->GetInterventionType());
 
     tAllowedActions allowedActions;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/ExecutorTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/backendUnitTests/ExecutorTests.cpp
@@ -36,8 +36,8 @@ void InterventionExecutorTest(unsigned int p_interventionType)
     GfInit(GF_LOGGING_DISABLE);
 
     // Load indicators from XML used for assisting the human with visual/audio indicators.
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, CONFIG_XML_DIR_FORMAT, GfDataDir());
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, CONFIG_XML_DIR_FORMAT, GfDataDir());
     IndicatorConfig::GetInstance()->LoadIndicatorData(path, INTERVENTION_TYPE_SHARED_CONTROL);
 
     SDAConfig config;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.cpp
@@ -107,8 +107,8 @@ tSoundData* IndicatorConfig::LoadSound(void* p_handle, std::string p_path)
 /// @return         A struct containing the screen position data
 tScreenPosition IndicatorConfig::LoadScreenPos(void* p_handle, const char* p_path)
 {
-    float xPos = GfParmGetNum(p_handle, p_path, PRM_ATTR_XPOS, nullptr, 0);
-    float yPos = GfParmGetNum(p_handle, p_path, PRM_ATTR_YPOS, nullptr, 0);
+    float xPos = GfParmGetNum(p_handle, p_path, PRM_ATTR_XPOS, nullptr, 0.0f);
+    float yPos = GfParmGetNum(p_handle, p_path, PRM_ATTR_YPOS, nullptr, 0.0f);
 
     // Check whether x- and y-pos are valid percentages in range [0,1]
     if (xPos < 0.0f || yPos < 0.0f || xPos > 1.0f || yPos > 1.0f)
@@ -125,8 +125,8 @@ tScreenPosition IndicatorConfig::LoadScreenPos(void* p_handle, const char* p_pat
 /// @return         A struct containing the dimensions data
 tTextureDimensions IndicatorConfig::LoadDimensions(void* p_handle, const char* p_path)
 {
-    float width = GfParmGetNum(p_handle, p_path, PRM_ATTR_WIDTH, nullptr, 0);
-    float height = GfParmGetNum(p_handle, p_path, PRM_ATTR_HEIGHT, nullptr, 0);
+    float width = GfParmGetNum(p_handle, p_path, PRM_ATTR_WIDTH, nullptr, 0.0f);
+    float height = GfParmGetNum(p_handle, p_path, PRM_ATTR_HEIGHT, nullptr, 0.0f);
 
     // Check whether width and height are not negative floats
     if (width < 0.0f || height < 0.0f)

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.cpp
@@ -26,10 +26,10 @@ void IndicatorConfig::LoadIndicatorData(const char* p_path, InterventionType p_i
     void* xmlHandle = GfParmReadFile(p_path, GFPARM_RMODE_STD);
 
     // Load the indicator data for every intervention action
-    char path[PATH_BUF_SIZE];
+    char path[MAX_PATH];
     for (int i = 0; i < NUM_INTERVENTION_ACTION; i++)
     {
-        snprintf(path, PATH_BUF_SIZE, "%s/%s/", PRM_SECT_INDICATORS, s_interventionActionString[i]);
+        snprintf(path, MAX_PATH, "%s/%s/", PRM_SECT_INDICATORS, s_interventionActionString[i]);
         m_indicatorData[i] = {
             static_cast<InterventionAction>(i),
             LoadSound(xmlHandle, std::string(path)),
@@ -39,6 +39,7 @@ void IndicatorConfig::LoadIndicatorData(const char* p_path, InterventionType p_i
 
     // Initially the active indicators are the neutral indicators.
     ResetActiveIndicatorsToNeutral();
+    GfParmReleaseHandle(xmlHandle);
 }
 
 /// @brief  Returns a vector of the indicator data
@@ -86,10 +87,7 @@ tSoundData* IndicatorConfig::LoadSound(void* p_handle, std::string p_path)
 
     const char* source = GfParmGetStr(p_handle, p_path.c_str(), PRM_ATTR_SRC, "");
 
-    char* sndPath = new char[PATH_BUF_SIZE];
-    snprintf(sndPath, PATH_BUF_SIZE, SOUNDS_DIR_FORMAT, GfDataDir(), source);
-    data->Path = sndPath;
-
+    snprintf(data->Path, MAX_PATH, SOUNDS_DIR_FORMAT, GfDataDir(), source);
     data->Looping = strcmp(GfParmGetStr(p_handle, p_path.c_str(), PRM_ATTR_LOOPING, VAL_NO), VAL_YES) == 0;
     data->LoopInterval = GfParmGetNum(p_handle, p_path.c_str(), PRM_ATTR_LOOP_INTERVAL, nullptr, 0);
 
@@ -150,7 +148,8 @@ tTextureData* IndicatorConfig::LoadTexture(void* p_handle, std::string p_path, I
     if (!GfParmExistsSection(p_handle, p_path.c_str())) return nullptr;
 
     tTextureData* data = new TextureData;
-    data->Path = GfParmGetStr(p_handle, p_path.c_str(), s_interventionTypeString[p_interventionType], "");
+
+    strcpy_s(data->Path, MAX_PATH, GfParmGetStr(p_handle, p_path.c_str(), s_interventionTypeString[p_interventionType], ""));
     data->ScrPos = LoadScreenPos(p_handle, p_path.c_str());
     data->Dimensions = LoadDimensions(p_handle, p_path.c_str());
     return data;
@@ -166,14 +165,15 @@ tTextData* IndicatorConfig::LoadText(void* p_handle, std::string p_path)
     if (!GfParmExistsSection(p_handle, p_path.c_str())) return nullptr;
 
     tTextData* data = new TextData;
-    data->Text = GfParmGetStr(p_handle, p_path.c_str(), PRM_ATTR_CONTENT, "");
+
+    strcpy_s(data->Text, MAX_TEXT_SIZE, GfParmGetStr(p_handle, p_path.c_str(), PRM_ATTR_CONTENT, ""));
     data->ScrPos = LoadScreenPos(p_handle, p_path.c_str());
 
     const char* fontFile = GfParmGetStr(p_handle, p_path.c_str(), PRM_ATTR_FONT, "");
     int fontSize = (int)GfParmGetNum(p_handle, p_path.c_str(), PRM_ATTR_FONT_SIZE, nullptr, 10.0);
 
-    char path[PATH_BUF_SIZE];
-    snprintf(path, PATH_BUF_SIZE, "%sdata/fonts/%s", GfDataDir(), fontFile);
+    char path[MAX_PATH];
+    snprintf(path, MAX_PATH, "%sdata/fonts/%s", GfDataDir(), fontFile);
     data->Font = new GfuiFontClass(path);
     data->Font->create(fontSize);
 

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorConfig.h
@@ -10,9 +10,6 @@
 #include "ConfigEnums.h"
 #include "IndicatorData.h"
 
-// Size of the path buffers, this will be used unchecked.
-#define PATH_BUF_SIZE 256
-
 // Location of the config.xml file with respect to the root data directory.
 #define CONFIG_XML_DIR_FORMAT "%sdata/indicators/Config.xml"
 #define SOUNDS_DIR_FORMAT     "%sdata/indicators/sound/%s"

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorData.h
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontend/IndicatorData.h
@@ -8,6 +8,9 @@
 
 #include "ConfigEnums.h"
 #include "guifont.h"
+#include "FileSystem.hpp"
+
+#define MAX_TEXT_SIZE 64
 
 /// @brief Represents a position on screen as percentages of the full screen.
 typedef struct ScreenPosition
@@ -25,7 +28,7 @@ typedef struct tTextureDimensions
 ///        The actual sounds are loaded from their path in the respective module.
 typedef struct SoundData
 {
-    const char* Path;
+    char Path[MAX_PATH];
     bool Looping;
     /// @brief How often it should loop, in seconds.
     float LoopInterval;
@@ -37,7 +40,7 @@ typedef struct SoundData
 ///        The actual textures are loaded from their path in the respective module.
 typedef struct TextureData
 {
-    const char* Path;
+    char Path[MAX_PATH];
     tScreenPosition ScrPos;
     tTextureDimensions Dimensions;
 } tTextureData;
@@ -45,7 +48,7 @@ typedef struct TextureData
 /// @brief Stores data related to drawing text on the Hud.
 typedef struct TextData
 {
-    const char* Text;
+    char Text[MAX_TEXT_SIZE];
     GfuiFontClass* Font;
     tScreenPosition ScrPos;
 } tTextData;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
@@ -14,8 +14,10 @@
 #include "IndicatorConfig.h"
 #include "Mediator.h"
 
-#define NUM_OF_TESTS    100
-#define TEST_XML_FILE   "test.xml"
+// Numbers in the xml file are stored with 6 decimal precision.
+#define FLOAT_FILE_WRITE_PRECISION 0.000001
+#define NUM_OF_TESTS               100
+#define TEST_XML_FILE              "test.xml"
 
 // Enum to help generating random indicator data
 // Enable multiple flags by doing FLAG1 | FLAG2 | FLAG3
@@ -227,6 +229,7 @@ protected:
         }
 
         GfParmWriteFile(nullptr, fileHandle, "test");
+        GfParmReleaseHandle(fileHandle);
 
         return path;
     }
@@ -263,8 +266,10 @@ protected:
         }
 
         ASSERT_STREQ(p_loadedTex->Path, p_rndTex->Path);
-        ASSERT_EQ(p_loadedTex->ScrPos.X, p_rndTex->ScrPos.X);
-        ASSERT_EQ(p_loadedTex->ScrPos.Y, p_rndTex->ScrPos.Y);
+        ASSERT_NEAR(p_loadedTex->ScrPos.X, p_rndTex->ScrPos.X, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_NEAR(p_loadedTex->ScrPos.Y, p_rndTex->ScrPos.Y, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_NEAR(p_loadedTex->Dimensions.Height, p_rndTex->Dimensions.Height, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_NEAR(p_loadedTex->Dimensions.Width, p_rndTex->Dimensions.Width, FLOAT_FILE_WRITE_PRECISION);
     }
 
     /// @brief             Asserts whether the loaded text is equal to the generated random text.
@@ -280,8 +285,8 @@ protected:
         }
 
         ASSERT_STREQ(p_loadedTxt->Text, p_rndTxt->Text);
-        ASSERT_EQ(p_loadedTxt->ScrPos.X, p_rndTxt->ScrPos.X);
-        ASSERT_EQ(p_loadedTxt->ScrPos.Y, p_rndTxt->ScrPos.Y);
+        ASSERT_NEAR(p_loadedTxt->ScrPos.X, p_rndTxt->ScrPos.X, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_NEAR(p_loadedTxt->ScrPos.Y, p_rndTxt->ScrPos.Y, FLOAT_FILE_WRITE_PRECISION);
     }
 
     /// @brief                    Asserts whether the loaded indicator is equal to the generated indicator

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
@@ -14,10 +14,8 @@
 #include "IndicatorConfig.h"
 #include "Mediator.h"
 
-// Numbers in the xml file are stored with 6 decimal precision.
-#define FLOAT_FILE_WRITE_PRECISION 0.000001
-#define NUM_OF_TESTS               100
-#define TEST_XML_FILE              "test.xml"
+#define NUM_OF_TESTS  100
+#define TEST_XML_FILE "test.xml"
 
 // Enum to help generating random indicator data
 // Enable multiple flags by doing FLAG1 | FLAG2 | FLAG3
@@ -185,7 +183,7 @@ protected:
         char* path = new char[MAX_PATH];
         getcwd(path, MAX_PATH);
         snprintf(path, MAX_PATH, "%s/" TEST_XML_FILE, path);
-        void* fileHandle = GfParmReadFile(path, GFPARM_RMODE_REREAD | GFPARM_RMODE_CREAT);
+        void* fileHandle = GfParmReadFile(path, GFPARM_RMODE_STD | GFPARM_RMODE_CREAT);
         GfParmClean(fileHandle);
 
         // Write all data to the xml file.
@@ -229,7 +227,6 @@ protected:
         }
 
         GfParmWriteFile(nullptr, fileHandle, "test");
-        GfParmReleaseHandle(fileHandle);
 
         return path;
     }
@@ -266,10 +263,10 @@ protected:
         }
 
         ASSERT_STREQ(p_loadedTex->Path, p_rndTex->Path);
-        ASSERT_NEAR(p_loadedTex->ScrPos.X, p_rndTex->ScrPos.X, FLOAT_FILE_WRITE_PRECISION);
-        ASSERT_NEAR(p_loadedTex->ScrPos.Y, p_rndTex->ScrPos.Y, FLOAT_FILE_WRITE_PRECISION);
-        ASSERT_NEAR(p_loadedTex->Dimensions.Height, p_rndTex->Dimensions.Height, FLOAT_FILE_WRITE_PRECISION);
-        ASSERT_NEAR(p_loadedTex->Dimensions.Width, p_rndTex->Dimensions.Width, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_EQ(p_loadedTex->ScrPos.X, p_rndTex->ScrPos.X);
+        ASSERT_EQ(p_loadedTex->ScrPos.Y, p_rndTex->ScrPos.Y);
+        ASSERT_EQ(p_loadedTex->Dimensions.Height, p_rndTex->Dimensions.Height);
+        ASSERT_EQ(p_loadedTex->Dimensions.Width, p_rndTex->Dimensions.Width);
     }
 
     /// @brief             Asserts whether the loaded text is equal to the generated random text.
@@ -285,8 +282,8 @@ protected:
         }
 
         ASSERT_STREQ(p_loadedTxt->Text, p_rndTxt->Text);
-        ASSERT_NEAR(p_loadedTxt->ScrPos.X, p_rndTxt->ScrPos.X, FLOAT_FILE_WRITE_PRECISION);
-        ASSERT_NEAR(p_loadedTxt->ScrPos.Y, p_rndTxt->ScrPos.Y, FLOAT_FILE_WRITE_PRECISION);
+        ASSERT_EQ(p_loadedTxt->ScrPos.X, p_rndTxt->ScrPos.X);
+        ASSERT_EQ(p_loadedTxt->ScrPos.Y, p_rndTxt->ScrPos.Y);
     }
 
     /// @brief                    Asserts whether the loaded indicator is equal to the generated indicator

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/frontendUnitTests/IndicatorConfigTests.cpp
@@ -15,7 +15,6 @@
 #include "Mediator.h"
 
 #define NUM_OF_TESTS    100
-#define MAX_TEXT_LENGTH 64
 #define TEST_XML_FILE   "test.xml"
 
 // Enum to help generating random indicator data
@@ -72,9 +71,7 @@ protected:
             data->LoopInterval = m_rnd.NextFloat(0, FLT_MAX);
         }
 
-        char* buf = new char[PATH_BUF_SIZE];
-        GenerateRandomCharArray(buf, m_rnd.NextInt(0, PATH_BUF_SIZE - 1));
-        data->Path = buf;
+        GenerateRandomCharArray(data->Path, m_rnd.NextInt(0, MAX_PATH - 1));
 
         return data;
     }
@@ -128,9 +125,7 @@ protected:
         // Otherwise generate random data object
         tTextureData* data = new TextureData;
 
-        char* buf = new char[PATH_BUF_SIZE];
-        GenerateRandomCharArray(buf, m_rnd.NextInt(0, PATH_BUF_SIZE - 1));
-        data->Path = buf;
+        GenerateRandomCharArray(data->Path, m_rnd.NextInt(0, MAX_PATH - 1));
         data->ScrPos = CreateRandomScreenPosition(p_gen);
         data->Dimensions = CreateRandomTextureDimensions(p_gen);
 
@@ -148,9 +143,7 @@ protected:
         // Otherwise generate random data object
         tTextData* data = new tTextData;
 
-        char* buf = new char[MAX_TEXT_LENGTH];
-        GenerateRandomCharArray(buf, m_rnd.NextInt(0, MAX_TEXT_LENGTH - 1));
-        data->Text = buf;
+        GenerateRandomCharArray(data->Text, m_rnd.NextInt(0, MAX_TEXT_SIZE - 1));
 
         data->ScrPos = CreateRandomScreenPosition(p_gen);
 
@@ -187,21 +180,21 @@ protected:
     const char* WriteIndicatorDataToXml(std::vector<tIndicatorData> p_data, InterventionType p_interventionType)
     {
         // Open or create the xml file to write to, clean the previous parameters.
-        char* path = new char[PATH_BUF_SIZE];
-        getcwd(path, PATH_BUF_SIZE);
-        snprintf(path, PATH_BUF_SIZE, "%s/" TEST_XML_FILE, path);
+        char* path = new char[MAX_PATH];
+        getcwd(path, MAX_PATH);
+        snprintf(path, MAX_PATH, "%s/" TEST_XML_FILE, path);
         void* fileHandle = GfParmReadFile(path, GFPARM_RMODE_REREAD | GFPARM_RMODE_CREAT);
         GfParmClean(fileHandle);
 
         // Write all data to the xml file.
-        char xmlSection[PATH_BUF_SIZE];
+        char xmlSection[MAX_PATH];
         for (int i = 0; i < NUM_INTERVENTION_ACTION; i++)
         {
             tIndicatorData data = p_data[i];
 
             if (data.Sound)
             {
-                snprintf(xmlSection, PATH_BUF_SIZE, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_SOUND);
+                snprintf(xmlSection, MAX_PATH, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_SOUND);
                 GfParmSetStr(fileHandle, xmlSection, PRM_ATTR_SRC, data.Sound->Path);
                 GfParmSetStr(fileHandle, xmlSection, PRM_ATTR_LOOPING, GfuiMenuBoolToStr(data.Sound->Looping));
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_LOOP_INTERVAL, nullptr, data.Sound->LoopInterval);
@@ -209,7 +202,7 @@ protected:
 
             if (data.Texture)
             {
-                snprintf(xmlSection, PATH_BUF_SIZE, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_TEXTURES);
+                snprintf(xmlSection, MAX_PATH, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_TEXTURES);
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_XPOS, nullptr, data.Texture->ScrPos.X);
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_YPOS, nullptr, data.Texture->ScrPos.Y);
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_WIDTH, nullptr, data.Texture->Dimensions.Width);
@@ -221,7 +214,7 @@ protected:
 
             if (data.Text)
             {
-                snprintf(xmlSection, PATH_BUF_SIZE, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_TEXT);
+                snprintf(xmlSection, MAX_PATH, "%s/%s/%s", PRM_SECT_INDICATORS, s_interventionActionString[i], PRM_SECT_TEXT);
                 GfParmSetStr(fileHandle, xmlSection, PRM_ATTR_CONTENT, data.Text->Text);
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_XPOS, nullptr, data.Text->ScrPos.X);
                 GfParmSetNum(fileHandle, xmlSection, PRM_ATTR_YPOS, nullptr, data.Text->ScrPos.Y);
@@ -250,8 +243,8 @@ protected:
             return;
         }
 
-        char* rndSndFullPath = new char[PATH_BUF_SIZE];
-        snprintf(rndSndFullPath, PATH_BUF_SIZE, SOUNDS_DIR_FORMAT, GfDataDir(), p_rndSnd->Path);
+        char* rndSndFullPath = new char[MAX_PATH];
+        snprintf(rndSndFullPath, MAX_PATH, SOUNDS_DIR_FORMAT, GfDataDir(), p_rndSnd->Path);
         ASSERT_STREQ(p_loadedSnd->Path, rndSndFullPath);
         ASSERT_EQ(p_loadedSnd->Looping, p_rndSnd->Looping);
         ASSERT_EQ(p_loadedSnd->LoopInterval, p_rndSnd->LoopInterval);

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/rppUtils/FileSystem.hpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/rppUtils/FileSystem.hpp
@@ -8,10 +8,10 @@
 #include <experimental/filesystem>
 
 #ifdef WIN32
-#define OS_SEPARATOR "\\"
+#define OS_SEPARATOR      "\\"
 #define OS_SEPARATOR_CHAR '\\'
 #else
-#define OS_SEPARATOR "/"
+#define OS_SEPARATOR      "/"
 #define OS_SEPARATOR_CHAR '/'
 #endif
 namespace filesystem = std::experimental::filesystem;

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/rppUtils/FileSystem.hpp
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/rppUtils/FileSystem.hpp
@@ -15,3 +15,5 @@
 #define OS_SEPARATOR_CHAR '/'
 #endif
 namespace filesystem = std::experimental::filesystem;
+
+#define MAX_PATH 260


### PR DESCRIPTION
This PR fixes:
- a couple of memory leaks caused by not releasing the indicator textures and xml file handles.
- a small bug where the blackbox status label was too small for moderate(100ms), increased the allocated size to fix this.
