### PR TITLE
V22F-962 Fix memory leak and interventions

### DIFF
--- a/speed-dreams/source-2.2.3/src/libs/robottools/rthumandriver.cpp
+++ b/speed-dreams/source-2.2.3/src/libs/robottools/rthumandriver.cpp
@@ -295,6 +295,12 @@ void HumanDriver::shutdown(const int index)
 
     // DAISI: Prevent usage of deleted recorder
     m_recorder = nullptr;
+    if (m_prevIntervention != INTERVENTION_TYPE_NO_SIGNALS)
+    {
+        // Reset internal value in the mediator back to what was selected on the Researcher Menu.
+        SMediator::GetInstance()->SetInterventionType(m_prevIntervention);
+        m_prevIntervention = INTERVENTION_TYPE_NO_SIGNALS;
+    }
 }
 
 /*

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -485,7 +485,6 @@ void ReleaseIndicatorTextures()
     {
         if (std::find(deletedPointers.begin(), deletedPointers.end(), m_textures[i]) != deletedPointers.end()) continue;
         deletedPointers.emplace_back(m_textures[i]);
-        GfTexFreeTexture(m_textures[i]->getTextureHandle());
         delete m_textures[i];
     }
     delete[] m_textures;

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -485,6 +485,7 @@ void ReleaseIndicatorTextures()
     {
         if (std::find(deletedPointers.begin(), deletedPointers.end(), m_textures[i]) != deletedPointers.end()) continue;
         deletedPointers.emplace_back(m_textures[i]);
+        GfTexFreeTexture(m_textures[i]->getTextureHandle());
         delete m_textures[i];
     }
     delete[] m_textures;

--- a/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
+++ b/speed-dreams/source-2.2.3/src/modules/graphic/ssggraph/grboard.cpp
@@ -41,7 +41,6 @@
 
 // DAISI: array to store the loaded (ssg) textures
 ssgSimpleState** m_textures = nullptr;
-int m_texturesSize = 0;
 
 #define ALIGN_CENTER 0
 #define ALIGN_LEFT   1
@@ -461,8 +460,7 @@ void cGrBoard::DispIndicatorText(tTextData* p_data)
 void LoadIndicatorTextures()
 {
     std::vector<tIndicatorData> indicators = IndicatorConfig::GetInstance()->GetIndicatorData();
-    m_texturesSize = indicators.size();
-    m_textures = new ssgSimpleState*[m_texturesSize];
+    m_textures = new ssgSimpleState*[indicators.size()];
     for (const tIndicatorData& indicator : indicators)
     {
         ssgSimpleState* texture = nullptr;
@@ -474,23 +472,6 @@ void LoadIndicatorTextures()
         m_textures[indicator.Action] = texture;
     }
 }
-
-// DAISI
-/// @brief Releases all indicator data textures, textures loaded in from the same path are pointing to the same texture.
-///        Therefore, we have to check whether the texture was already deleted.
-void ReleaseIndicatorTextures()
-{
-    std::vector<ssgSimpleState*> deletedPointers;
-    for (int i = 0; i < m_texturesSize; i++)
-    {
-        if (std::find(deletedPointers.begin(), deletedPointers.end(), m_textures[i]) != deletedPointers.end()) continue;
-        deletedPointers.emplace_back(m_textures[i]);
-        delete m_textures[i];
-    }
-    delete[] m_textures;
-    m_textures = nullptr;
-}
-
 
 void grInitBoardCar(tCarElt *car)
 {
@@ -725,8 +706,7 @@ void cGrBoard::initBoard(void)
 {
 }
 
-/// @brief Shuts down the dashboard by releasing the indicator textures.
+/// @brief Shuts down the dashboard
 void cGrBoard::shutdown(void)
 {
-    if (m_textures) ReleaseIndicatorTextures();
 }

--- a/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
+++ b/speed-dreams/source-2.2.3/src/simulatedDrivingAssistance/CHANGES.txt
@@ -429,7 +429,6 @@ Changed:
                     added   DispIndicatorIcon();
                     added   DispIndicatorText();
                     added   LoadIndicatorTextures()
-                    added   ReleaseIndicatorTextures()
 
                     changed cGrBoard(): removed assignments of removed members
                     changed ~cGrBoard(): removed deletes of removed members


### PR DESCRIPTION
- Fixes the likely cause of `DAISI: ssgBase.cxx:78: virtual ssgBase::~ssgBase(): Assertion `refc == 0' failed.`, hasn't happened to me for 30min+ of testing the game.
- Fixed interventions that would not turn on again after restarting the game. This happened when the game was exited while interventions were toggled of via the button 'toggle interventions on/off'. This then left the internal mediator staat on on `INTERVENTION_TYPE_NO_SIGNALS`. This is now fixed.